### PR TITLE
Various cleanups for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,20 +76,36 @@ jobs:
         FEATURES: modern
   build-freebsd:
     name: FreeBSD
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - uses: actions/setup-ruby@v1
+    - name: Enable KVM group perms
+      run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+    - run: sudo apt-get -y install vagrant vagrant-libvirt libvirt-daemon-system
+    - run: sudo service libvirtd start
+    - run: sudo chmod 666 /var/run/libvirt/libvirt-sock
     - run: make ci-freebsd
   build-netbsd:
     name: NetBSD
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: Enable KVM group perms
+      run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+    - run: sudo apt-get -y install vagrant vagrant-libvirt libvirt-daemon-system
+    - run: sudo service libvirtd start
+    - run: sudo chmod 666 /var/run/libvirt/libvirt-sock
     - run: make ci-netbsd
   build-mac:
     name: macOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Linux (Debian bullseye amd64)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-ruby@v1
     - run: make ci-bullseye
     - uses: actions/upload-artifact@v2
@@ -17,7 +17,7 @@ jobs:
     name: Linux (Debian bullseye armel)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-ruby@v1
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
@@ -35,7 +35,7 @@ jobs:
     name: Linux (Debian bullseye arm64)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-ruby@v1
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
@@ -53,14 +53,14 @@ jobs:
     name: Linux (oldest Rust)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-ruby@v1
     - run: make ci-oldest
   build-stable:
     name: Linux (Rust stable)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-ruby@v1
     - run: make ci-stable
       env:
@@ -69,7 +69,7 @@ jobs:
     name: Linux (Rust nightly)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-ruby@v1
     - run: make ci-nightly
       env:
@@ -78,7 +78,7 @@ jobs:
     name: FreeBSD
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: actions/setup-ruby@v1
@@ -95,7 +95,7 @@ jobs:
     name: NetBSD
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Enable KVM group perms
@@ -111,7 +111,7 @@ jobs:
     name: macOS
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: brew install ruby asciidoctor rust
     - run: make test-full
       env:

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,6 @@
 extern crate autocfg;
 
 fn main() {
-    let ac = autocfg::new();
-    ac.emit_rustc_version(1, 37);
-    ac.emit_trait_cfg(
-        "std::ops::RangeBounds<std::ops::Range<usize>>",
-        "has_range_bounds",
-    );
-
     // Ideally we'd allow arbitrary byte paths here, but Rust's env! doesn't support that.  If this
     // becomes a problem, we can always percent-encode as a workaround.
     let sharedir = match (

--- a/src/lib/codec/codecs/uuencode.rs
+++ b/src/lib/codec/codecs/uuencode.rs
@@ -1,6 +1,6 @@
 #![allow(unknown_lints)]
 #![allow(bare_trait_objects)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::manual_range_contains))]
+#![allow(clippy::manual_range_contains)]
 
 use codec::helpers::codecs::FilteredDecoder;
 use codec::Codec;

--- a/src/lib/codec/codecs/vis.rs
+++ b/src/lib/codec/codecs/vis.rs
@@ -1,6 +1,6 @@
 #![allow(unknown_lints)]
 #![allow(bare_trait_objects)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::manual_range_contains))]
+#![allow(clippy::manual_range_contains)]
 
 use codec::Codec;
 use codec::CodecSettings;

--- a/src/lib/codec/mod.rs
+++ b/src/lib/codec/mod.rs
@@ -237,33 +237,11 @@ impl<R: BufRead, C: Codec> CodecReader<R, C> {
         }
     }
 
-    #[cfg(rustc_1_37)]
     fn memmove<B>(sl: &mut [u8], src: B, dest: usize)
     where
         B: ops::RangeBounds<usize> + IntoIterator<Item = usize>,
     {
         sl.copy_within(src, dest)
-    }
-
-    #[cfg(all(not(rustc_1_37), has_range_bounds))]
-    fn memmove<B>(sl: &mut [u8], src: B, dest: usize)
-    where
-        B: ops::RangeBounds<usize> + IntoIterator<Item = usize>,
-    {
-        match src.start_bound() {
-            ops::Bound::Included(&x) if x == dest => return,
-            _ => (),
-        };
-        for (j, i) in src.into_iter().enumerate() {
-            sl[j] = sl[i + dest];
-        }
-    }
-
-    #[cfg(all(not(rustc_1_37), not(has_range_bounds)))]
-    fn memmove(sl: &mut [u8], src: ops::Range<usize>, dest: usize) {
-        for (j, i) in src.into_iter().enumerate() {
-            sl[j] = sl[i + dest];
-        }
     }
 }
 


### PR DESCRIPTION
Fix some warnings with a modern version of Clippy, use nested virtualization on Ubuntu, and switch to the latest version of actions/checkout.