### PR TITLE
Fix several issues with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,26 +15,6 @@ jobs:
       with:
         name: bullseye-amd64-deb
         path: target/assets/muter_*.deb
-  build-bullseye-armel:
-    name: Linux (Debian bullseye armel)
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.1
-    - run: |
-        echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
-        sudo systemctl restart docker.service
-        docker version -f '{{.Server.Experimental}}'
-    - uses: docker/setup-qemu-action@v1
-    - run: make ci-bullseye
-      env:
-        PLATFORM: linux/arm/v5
-    - uses: actions/upload-artifact@v6
-      with:
-        name: bullseye-armel-deb
-        path: target/assets/muter_*.deb
   build-bullseye-arm64:
     name: Linux (Debian bullseye arm64)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,39 +74,6 @@ jobs:
     - run: make ci-nightly
       env:
         FEATURES: modern
-  build-freebsd:
-    name: FreeBSD
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-ruby@v1
-    - name: Enable KVM group perms
-      run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-    - run: sudo apt-get -y install vagrant vagrant-libvirt libvirt-daemon-system
-    - run: sudo service libvirtd start
-    - run: sudo chmod 666 /var/run/libvirt/libvirt-sock
-    - run: make ci-freebsd
-  build-netbsd:
-    name: NetBSD
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-    - name: Enable KVM group perms
-      run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-    - run: sudo apt-get -y install vagrant vagrant-libvirt libvirt-daemon-system
-    - run: sudo service libvirtd start
-    - run: sudo chmod 666 /var/run/libvirt/libvirt-sock
-    - run: make ci-netbsd
   build-mac:
     name: macOS
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1
     - run: make ci-bullseye
     - uses: actions/upload-artifact@v6
       with:
@@ -18,7 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
@@ -36,7 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker.service
@@ -54,14 +60,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1
     - run: make ci-oldest
   build-stable:
     name: Linux (Rust stable)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1
     - run: make ci-stable
       env:
         FEATURES: modern
@@ -70,7 +80,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.1
     - run: make ci-nightly
       env:
         FEATURES: modern

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Linux (Debian bullseye amd64)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: actions/setup-ruby@v1
     - run: make ci-bullseye
     - uses: actions/upload-artifact@v6
@@ -17,7 +17,7 @@ jobs:
     name: Linux (Debian bullseye armel)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: actions/setup-ruby@v1
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
@@ -35,7 +35,7 @@ jobs:
     name: Linux (Debian bullseye arm64)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: actions/setup-ruby@v1
     - run: |
         echo '{"experimental": true}' | sudo tee /etc/docker/daemon.json
@@ -53,14 +53,14 @@ jobs:
     name: Linux (oldest Rust)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: actions/setup-ruby@v1
     - run: make ci-oldest
   build-stable:
     name: Linux (Rust stable)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: actions/setup-ruby@v1
     - run: make ci-stable
       env:
@@ -69,7 +69,7 @@ jobs:
     name: Linux (Rust nightly)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - uses: actions/setup-ruby@v1
     - run: make ci-nightly
       env:
@@ -78,7 +78,7 @@ jobs:
     name: FreeBSD
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - uses: actions/setup-ruby@v1
@@ -95,7 +95,7 @@ jobs:
     name: NetBSD
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Enable KVM group perms
@@ -111,7 +111,7 @@ jobs:
     name: macOS
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - run: brew install ruby asciidoctor rust
     - run: make test-full
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-ruby@v1
     - run: make ci-bullseye
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v6
       with:
         name: bullseye-amd64-deb
         path: target/assets/muter_*.deb
@@ -27,7 +27,7 @@ jobs:
     - run: make ci-bullseye
       env:
         PLATFORM: linux/arm/v5
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v6
       with:
         name: bullseye-armel-deb
         path: target/assets/muter_*.deb
@@ -45,7 +45,7 @@ jobs:
     - run: make ci-bullseye
       env:
         PLATFORM: linux/arm64
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v6
       with:
         name: bullseye-arm64-deb
         path: target/assets/muter_*.deb

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ include = [
 ]
 categories = ["command-line-utilities", "encoding"]
 keywords = ["encoding"]
+rust-version = "1.41.1"
 
 [lib]
 name = "muter"

--- a/src/lib/chain/mod.rs
+++ b/src/lib/chain/mod.rs
@@ -116,7 +116,7 @@ impl<'a> Chain<'a> {
         }
     }
 
-    fn parse(chain: &str, dir: Direction) -> Result<Vec<ChainTransform>, Error> {
+    fn parse(chain: &str, dir: Direction) -> Result<Vec<ChainTransform<'_>>, Error> {
         let iter = chain.split(':').map(|s| Self::parse_unit(s, dir));
         match dir {
             Direction::Forward => iter.collect(),
@@ -124,7 +124,7 @@ impl<'a> Chain<'a> {
         }
     }
 
-    fn parse_unit(unit: &str, d: Direction) -> Result<ChainTransform, Error> {
+    fn parse_unit(unit: &str, d: Direction) -> Result<ChainTransform<'_>, Error> {
         if unit.is_empty() {
             return Err(Error::InvalidName(String::from(unit)));
         }

--- a/src/lib/codec/codecs/checksum.rs
+++ b/src/lib/codec/codecs/checksum.rs
@@ -219,8 +219,8 @@ impl CodecTransform for TransformFactory {
         let length = s.int_arg("length")?;
         let endianness: Vec<_> = s
             .args
-            .iter()
-            .filter_map(|(s, _)| Endianness::from_str(s))
+            .keys()
+            .filter_map(|s| Endianness::from_str(s))
             .collect();
         let args: Vec<_> = s
             .args

--- a/src/lib/codec/codecs/quotedprintable.rs
+++ b/src/lib/codec/codecs/quotedprintable.rs
@@ -363,7 +363,7 @@ impl Codec for Encoder {
             if let Some(linelen) = self.linelen {
                 // +1 for b'='.  Note that we don't count the LF, since the RFC says not to.
                 if enclen + curline + 1 > linelen {
-                    outp[j..j + 2].copy_from_slice(&[b'=', b'\n']);
+                    outp[j..j + 2].copy_from_slice(b"=\n");
                     j += 2;
                     curline = 0;
                 }


### PR DESCRIPTION
Fix several issues with CI, including the following:

* Update `actions/checkout`.
* Update `actions/upload-artifact`.
* Switch to `ruby/setup-ruby` and a modern version of Ruby.
* Remove FreeBSD and NetBSD due to a lack of Vagrant.
* Remove Debian armel due to a lack of Docker images.
* Fix several Clippy warnings.
* Set the Rust version to silence Clippy warnings about newer features. 