### PR TITLE
Test on Debian 12, not 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,21 +2,21 @@ name: ci
 on: [push, pull_request]
 
 jobs:
-  build-bullseye:
-    name: Linux (Debian bullseye amd64)
+  build-bookworm:
+    name: Linux (Debian bookworm amd64)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.1
-    - run: make ci-bullseye
+    - run: make ci-bookworm
     - uses: actions/upload-artifact@v6
       with:
-        name: bullseye-amd64-deb
+        name: bookworm-amd64-deb
         path: target/assets/muter_*.deb
-  build-bullseye-arm64:
-    name: Linux (Debian bullseye arm64)
+  build-bookworm-arm64:
+    name: Linux (Debian bookworm arm64)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -28,12 +28,12 @@ jobs:
         sudo systemctl restart docker.service
         docker version -f '{{.Server.Experimental}}'
     - uses: docker/setup-qemu-action@v1
-    - run: make ci-bullseye
+    - run: make ci-bookworm
       env:
         PLATFORM: linux/arm64
     - uses: actions/upload-artifact@v6
       with:
-        name: bullseye-arm64-deb
+        name: bookworm-arm64-deb
         path: target/assets/muter_*.deb
   build-oldest:
     name: Linux (oldest Rust)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Test configuration.
-GROUPS := bullseye stable nightly oldest
+GROUPS := bookworm stable nightly oldest
 DOCKER_FILES := $(patsubst %,test/Dockerfile.%,$(GROUPS))
 DOCKER_STAMPS := $(patsubst %,test/Dockerfile.%.stamp,$(GROUPS))
 CI_TARGETS := $(patsubst %,ci-%,$(GROUPS))

--- a/test/Dockerfile.bookworm.erb
+++ b/test/Dockerfile.bookworm.erb
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 <%= erb 'test/include/apt.erb' -%>
 


### PR DESCRIPTION
Debian 11 has too old of a Cargo version for us to use going forward, since one of our dependencies on a security update needs newer features (specifically, the `resolver` feature).  Update to Debian 12 to make things work as expected.